### PR TITLE
response interceptor 추가

### DIFF
--- a/src/global/TransformationInterceptor.ts
+++ b/src/global/TransformationInterceptor.ts
@@ -1,0 +1,28 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, map } from 'rxjs';
+
+export interface Response<T> {
+  data: T;
+}
+
+@Injectable()
+export class TransformationInterceptor<T>
+  implements NestInterceptor<T, Response<T>>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<Response<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        data,
+        statusCode: context.switchToHttp().getResponse().statusCode,
+      })),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as config from 'config';
+import { TransformationInterceptor } from './global/TransformationInterceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -8,6 +9,7 @@ async function bootstrap() {
   const port = serverConfig.port;
 
   app.enableCors();
+  app.useGlobalInterceptors(new TransformationInterceptor());
   await app.listen(port);
 }
 bootstrap();


### PR DESCRIPTION
공통 response 값을 출력해주는 interceptor를 만들기로 한다.
```js
{
	data: <T>, // 값
	statusCode: // httpcode
}
```
만든 interceptor에서 예러나 예외는 규원님이 만들고 계신 exception-filter에서 결과값을 보여주는 거 같더라구요.
그래서 성공일때만 `TransformationInterceptor` 여기로 들어오는데 성공일 때의 `message`도 추가해야할까요?

`message` 추가하게 된다면
[참고자료](https://stackoverflow.com/questions/71342465/use-custom-interceptors-for-the-response)
혹시 만약에 성공일때도 message가 필요하면 위 링크 한번 보시구, 컨트롤러에 데코레이터로 값을 넣는데 괜찮을지랑, 아니면 모든 값들을 
```js
return { message: 'User updated', res: result };   
```
message, res 이렇게 값을 할지 한번 얘기해봅시다!.

1. message 추가할지
2. message를 추가한다면
    1. return { message: 'User updated', res: result }; 이런식으로 message, res를 넘겨줄지
    2. @ResponseMessage(USER_UPDATED)으로 데코레이션 달것인지
   
## 응답값
- notice get
<img width="744" alt="image" src="https://user-images.githubusercontent.com/38110785/197439022-99645b6a-9ad1-4fd8-a20e-4dcc6c1a5387.png">
- 로그인
<img width="722" alt="스크린샷 2022-10-24 오전 11 52 00" src="https://user-images.githubusercontent.com/38110785/197439054-7ab45e1b-2d71-43a1-9dda-226dd2f8c016.png">

